### PR TITLE
Fix broken Star History chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,4 +112,4 @@ KindleForge is licensed under `GPLv3`, with all other KindleTweaks projects (inc
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=KindleTweaks/KindleForge&type=date&legend=top-left)](https://www.star-history.com/#KindleTweaks/KindleForge&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=KindleTweaks/KindleForge&type=date&legend=top-left)](https://star-history.dera.page/#KindleTweaks/KindleForge&type=date&legend=top-left)


### PR DESCRIPTION
The Star History chart is currently broken due to GitHub stargazer API restrictions, so it no longer renders on the README. This PR updates the chart to a working endpoint so it displays correctly again.